### PR TITLE
fix(android): add 16KB page size support for Android 15+ (#2)

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -5,6 +5,14 @@ set(PACKAGE_NAME RNHttpServer)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_CXX_STANDARD 20)
 
+# Android 16KB page size support (AOSP Android 15+):
+# The JNI wrapper .so must be built with 16KB alignment so the app loads on devices
+# that use 16KB memory pages. Only arm64-v8a and x86_64 support 16KB; prebuilt
+# librn_http_server.so in android/libs/ should also be rebuilt with 16KB alignment.
+if(ANDROID_ABI STREQUAL "arm64-v8a" OR ANDROID_ABI STREQUAL "x86_64")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384")
+endif()
+
 # Add our custom implementation and JNI adapter
 add_library(${PACKAGE_NAME} SHARED
         ../cpp/HybridHttpServer.cpp

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,8 @@ android {
             cmake {
                 cppFlags "-fexceptions", "-frtti", "-std=c++20"
                 arguments "-DANDROID_STL=c++_shared"
+                // Enable 16KB page size support for NDK r28+ toolchain (optional; CMakeLists.txt linker flag ensures alignment on older NDK)
+                arguments "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
                 abiFilters (*reactNativeArchitectures())
             }
         }


### PR DESCRIPTION
fix(android): add 16KB page size support for Android 15+

- CMakeLists.txt: set linker flag -Wl,-z,max-page-size=16384 for arm64-v8a
  and x86_64 so the JNI wrapper .so is built with 16KB alignment. Required when the app runs on devices with 16KB memory pages (AOSP Android 15+).
- build.gradle: pass ANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON to CMake for NDK r28+ toolchain compatibility.